### PR TITLE
Fix false-positive cases for the ParametersAsHash behaviour

### DIFF
--- a/lib/strainer/behaviors/parameters_as_hash.rb
+++ b/lib/strainer/behaviors/parameters_as_hash.rb
@@ -33,6 +33,10 @@ module Strainer
           klass == ::Hash || super
         end
         alias kind_of? is_a?
+
+        def convert_value_to_parameters(value)
+          value.is_a?(::ActionController::Parameters) ? value : super
+        end
       end
 
       module ReConvertValue


### PR DESCRIPTION
Fix false-positive cases when `ActionController::Parameters` using deep values access

```ruby
params = ActionController::Parameters.new(key1: { key2: 1 })
params[:key1][:key2]
```